### PR TITLE
Add major version lock

### DIFF
--- a/recipes/android-parallel-testing-unit-test-shards.md
+++ b/recipes/android-parallel-testing-unit-test-shards.md
@@ -66,8 +66,8 @@ workflows:
 
   _test:
     steps:
-    - git-clone: { }
-    - android-unit-test:
+    - git-clone@6: { }
+    - android-unit-test@1:
         inputs:
         - module: $MODULE
         - variant: $VARIANT

--- a/recipes/android-parallel-ui-tests-on-multiple-devices.md
+++ b/recipes/android-parallel-ui-tests-on-multiple-devices.md
@@ -59,12 +59,12 @@ stages:
 workflows:
   build_for_ui_testing:
     steps:
-    - git-clone: { }
-    - android-build-for-ui-testing:
+    - git-clone@6: { }
+    - android-build-for-ui-testing@0:
         inputs:
         - module: app
         - variant: debug
-    - deploy-to-bitrise-io: { }
+    - deploy-to-bitrise-io@2: { }
 
   ui_test_on_phone:
     envs:
@@ -92,7 +92,7 @@ workflows:
 
   _pull_apks:
     steps:
-    - artifact-pull:
+    - artifact-pull@1:
         inputs:
         - artifact_sources: build_for_ui_testing.build_for_ui_testing.*
         - export_map: |-
@@ -101,9 +101,9 @@ workflows:
 
   _run_tests:
     steps:
-    - avd-manager:
+    - avd-manager@1:
         inputs:
         - profile: $EMULATOR_PROFILE
-    - wait-for-android-emulator: { }
-    - android-instrumented-test: { }
+    - wait-for-android-emulator@1: { }
+    - android-instrumented-test@0: { }
 ```

--- a/recipes/android-parallel-unit-and-ui-tests.md
+++ b/recipes/android-parallel-unit-and-ui-tests.md
@@ -53,20 +53,20 @@ stages:
 workflows:
   unit_tests:
     steps:
-    - git-clone: { }
-    - android-unit-test:
+    - git-clone@6: { }
+    - android-unit-test@1:
         inputs:
         - module: app
         - variant: debug
 
   ui_tests:
     steps:
-    - git-clone: { }
-    - android-build-for-ui-testing:
+    - git-clone@6: { }
+    - android-build-for-ui-testing@0:
         inputs:
         - module: app
         - variant: debug
-    - avd-manager: { }
-    - wait-for-android-emulator: { }
-    - android-instrumented-test: { }
+    - avd-manager@1: { }
+    - wait-for-android-emulator@1: { }
+    - android-instrumented-test@0: { }
 ```

--- a/recipes/ios-merging-test-results-and-deploying-to-the-test-reports-add-on.md
+++ b/recipes/ios-merging-test-results-and-deploying-to-the-test-reports-add-on.md
@@ -74,38 +74,38 @@ stages:
 workflows:
   build_tests:
     steps:
-    - git-clone: {}
-    - xcode-build-for-test:
+    - git-clone@6: {}
+    - xcode-build-for-test@2:
         inputs:
         - destination: generic/platform=iOS Simulator
-    - deploy-to-bitrise-io: {}
+    - deploy-to-bitrise-io@2: {}
 
   run_ui_tests:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_TEST_BUNDLE_PATH/BullsEye_UITests_iphonesimulator15.2-arm64-x86_64.xctestrun"
         - destination: platform=iOS Simulator,name=iPhone 12 Pro Max
-    - deploy-to-bitrise-io: {}
+    - deploy-to-bitrise-io@2: {}
 
   run_unit_tests:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_TEST_BUNDLE_PATH/BullsEye_UnitTests_iphonesimulator15.2-arm64-x86_64.xctestrun"
         - destination: platform=iOS Simulator,name=iPhone 12 Pro Max
-    - deploy-to-bitrise-io: {}
+    - deploy-to-bitrise-io@2: {}
 
   deploy_test_results:
     steps:
-    - artifact-pull:
+    - artifact-pull@1:
         inputs:
         - artifact_sources: run_tests_groups.*
-    - script:
+    - script@1:
         inputs:
         - content: |
             #!/usr/bin/env bash
@@ -133,15 +133,15 @@ workflows:
                 ((i++))
               fi
             done
-    - deploy-to-bitrise-io: {}
+    - deploy-to-bitrise-io@2: {}
 
   _pull_test_bundle:
     steps:
-    - artifact-pull:
+    - artifact-pull@1:
         inputs:
         - export_map: 'BITRISE_TEST_BUNDLE_ZIP_PATH: .*\.zip'
         - artifact_sources: build_tests.build_tests.*
-    - script:
+    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/recipes/ios-run-test-groups-in-parallel.md
+++ b/recipes/ios-run-test-groups-in-parallel.md
@@ -64,17 +64,17 @@ stages:
 workflows:
   build_tests:
     steps:
-    - git-clone: {}
-    - xcode-build-for-test:
+    - git-clone@6: {}
+    - xcode-build-for-test@2:
         inputs:
         - destination: generic/platform=iOS Simulator
-    - deploy-to-bitrise-io: {}
+    - deploy-to-bitrise-io@2: {}
 
   run_ui_tests:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_TEST_BUNDLE_PATH/BullsEye_UITests_iphonesimulator15.2-arm64-x86_64.xctestrun"
         - destination: platform=iOS Simulator,name=iPhone 12 Pro Max
@@ -83,18 +83,18 @@ workflows:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_TEST_BUNDLE_PATH/BullsEye_UnitTests_iphonesimulator15.2-arm64-x86_64.xctestrun"
         - destination: platform=iOS Simulator,name=iPhone 12 Pro Max
 
   _pull_test_bundle:
     steps:
-    - artifact-pull:
+    - artifact-pull@1:
         inputs:
         - export_map: 'BITRISE_TEST_BUNDLE_ZIP_PATH: .*\.zip'
         - artifact_sources: build_tests.build_tests.*
-    - script:
+    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/recipes/ios-run-tests-in-parallel-on-multiple-simulators.md
+++ b/recipes/ios-run-tests-in-parallel-on-multiple-simulators.md
@@ -66,17 +66,17 @@ stages:
 workflows:
   build_tests:
     steps:
-    - git-clone: {}
-    - xcode-build-for-test:
+    - git-clone@6: {}
+    - xcode-build-for-test@2:
         inputs:
         - destination: generic/platform=iOS Simulator
-    - deploy-to-bitrise-io: {}
+    - deploy-to-bitrise-io@2: {}
 
   run_tests_iPhone:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_XCTESTRUN_FILE_PATH"
         - destination: platform=iOS Simulator,name=iPhone 12 Pro Max
@@ -85,7 +85,7 @@ workflows:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_XCTESTRUN_FILE_PATH"
         - destination: platform=iOS Simulator,name=iPad (9th generation)
@@ -94,18 +94,18 @@ workflows:
     before_run:
     - _pull_test_bundle
     steps:
-    - xcode-test-without-building:
+    - xcode-test-without-building@0:
         inputs:
         - xctestrun: "$BITRISE_XCTESTRUN_FILE_PATH"
         - destination: platform=iOS Simulator,name=iPod touch (7th generation)
 
   _pull_test_bundle:
     steps:
-    - artifact-pull:
+    - artifact-pull@1:
         inputs:
         - export_map: 'BITRISE_TEST_BUNDLE_ZIP_PATH: .*\.zip'
         - artifact_sources: build_tests.build_tests.*
-    - script:
+    - script@1:
         inputs:
         - content: |-
             #!/usr/bin/env bash


### PR DESCRIPTION
The pipeline recipes now have the steps locked to their major versions. This will disable the automatic step major version upgrades. 